### PR TITLE
Allow the client to validate the remote certificate

### DIFF
--- a/main/src/ReCode.Cocoon.Proxy/Proxy/CocoonProxyOptions.cs
+++ b/main/src/ReCode.Cocoon.Proxy/Proxy/CocoonProxyOptions.cs
@@ -1,0 +1,9 @@
+﻿using System.Net.Security;
+
+namespace ReCode.Cocoon.Proxy.Proxy
+{
+    public class CocoonProxyOptions
+    {
+        public RemoteCertificateValidationCallback? RemoteCertificateValidationCallback { get; set; }
+    }
+}

--- a/main/src/ReCode.Cocoon.Proxy/Proxy/CocoonProxyServicesExtensions.cs
+++ b/main/src/ReCode.Cocoon.Proxy/Proxy/CocoonProxyServicesExtensions.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.ReverseProxy.Service.Proxy;
 using ReCode.Cocoon.Proxy.Proxy;
 
 // ReSharper disable once CheckNamespace
@@ -9,9 +11,22 @@ namespace Microsoft.Extensions.DependencyInjection
     {
         public static IReverseProxyBuilder AddCocoonProxy(this IServiceCollection services, IConfiguration configuration)
         {
-            services.AddSingleton<CocoonProxy>();
-            return services.AddReverseProxy()
-                .LoadFromConfig(configuration.GetSection("ReverseProxy"));
+            return AddCocoonProxy(services, configuration, null);
+        }
+
+        public static IReverseProxyBuilder AddCocoonProxy(this IServiceCollection services, IConfiguration configuration, CocoonProxyOptions? cocoonProxyOptions)
+        {
+            services.AddSingleton<CocoonProxy>(provider => new CocoonProxy(
+                configuration, 
+                provider.GetService<ILogger<CocoonProxy>>(), 
+                provider.GetService<IHttpProxy>(), cocoonProxyOptions));
+
+            return ReverseProxyBuilder(services, configuration);
+        }
+
+        private static IReverseProxyBuilder ReverseProxyBuilder(IServiceCollection services, IConfiguration configuration)
+        {
+            return services.AddReverseProxy().LoadFromConfig(configuration.GetSection("ReverseProxy"));
         }
     }
 }


### PR DESCRIPTION
Allow the client to validate the remote certificate, useful in development and self certificate scenarios. I needed this change to allow us to begin wrapping an internal application.