### PR TITLE
Feature/run legacy tests in build

### DIFF
--- a/.github/workflows/dotnet-develop.yml
+++ b/.github/workflows/dotnet-develop.yml
@@ -39,3 +39,7 @@ jobs:
     - name: Test
       run: dotnet test -c Release --no-build --verbosity normal .\test\ReCode.Cocoon.Proxy.Tests
       working-directory: .\main
+    - name: BuildNet45
+      run: |
+        cd "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\"
+        .\MSBuild.exe $Env:GITHUB_WORKSPACE\main\Cocoon.sln

--- a/.github/workflows/dotnet-develop.yml
+++ b/.github/workflows/dotnet-develop.yml
@@ -42,4 +42,7 @@ jobs:
     - name: BuildNet45
       run: |
         cd "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\"
-        .\MSBuild.exe $Env:GITHUB_WORKSPACE\main\Cocoon.sln
+        .\MSBuild.exe $Env:GITHUB_WORKSPACE\main\Cocoon.sln -m /p:Configuration=Release
+    - name: ConsoleRunXUnitLegacyTests
+      run: |
+        ~/.nuget/packages/xunit.runner.console/2.4.1/tools/net472/xunit.console.exe $Env:GITHUB_WORKSPACE\main\test\ReCode.Cocoon.Legacy.Tests\bin\Debug\net45\ReCode.Cocoon.Legacy.Tests.dll

--- a/.github/workflows/dotnet-develop.yml
+++ b/.github/workflows/dotnet-develop.yml
@@ -45,4 +45,4 @@ jobs:
         .\MSBuild.exe $Env:GITHUB_WORKSPACE\main\Cocoon.sln -m /p:Configuration=Release
     - name: ConsoleRunXUnitLegacyTests
       run: |
-        ~/.nuget/packages/xunit.runner.console/2.4.1/tools/net472/xunit.console.exe $Env:GITHUB_WORKSPACE\main\test\ReCode.Cocoon.Legacy.Tests\bin\Debug\net45\ReCode.Cocoon.Legacy.Tests.dll
+        ~/.nuget/packages/xunit.runner.console/2.4.1/tools/net472/xunit.console.exe $Env:GITHUB_WORKSPACE\main\test\ReCode.Cocoon.Legacy.Tests\bin\Release\net45\ReCode.Cocoon.Legacy.Tests.dll

--- a/main/Cocoon.sln
+++ b/main/Cocoon.sln
@@ -30,6 +30,11 @@ ProjectSection(SolutionItems) = preProject
 	Directory.Build.props = Directory.Build.props
 EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{6AD14C47-2BE5-4428-AB83-641684162C8A}"
+ProjectSection(SolutionItems) = preProject
+	..\.github\workflows\dotnet-develop.yml = ..\.github\workflows\dotnet-develop.yml
+EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/main/test/ReCode.Cocoon.Legacy.Tests/Auth/AuthApiHandlerTests.cs
+++ b/main/test/ReCode.Cocoon.Legacy.Tests/Auth/AuthApiHandlerTests.cs
@@ -66,7 +66,7 @@ namespace ReCode.Cocoon.Legacy.Tests.Auth
         [Fact]
         public void HandlerIsReusable()
         {
-            Assert.False(_sut.IsReusable);
+            Assert.True(_sut.IsReusable);
         }
     }
 }

--- a/main/test/ReCode.Cocoon.Legacy.Tests/Auth/AuthApiHandlerTests.cs
+++ b/main/test/ReCode.Cocoon.Legacy.Tests/Auth/AuthApiHandlerTests.cs
@@ -66,7 +66,7 @@ namespace ReCode.Cocoon.Legacy.Tests.Auth
         [Fact]
         public void HandlerIsReusable()
         {
-            Assert.True(_sut.IsReusable);
+            Assert.False(_sut.IsReusable);
         }
     }
 }

--- a/main/test/ReCode.Cocoon.Legacy.Tests/ReCode.Cocoon.Legacy.Tests.csproj
+++ b/main/test/ReCode.Cocoon.Legacy.Tests/ReCode.Cocoon.Legacy.Tests.csproj
@@ -12,6 +12,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.console" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
I've not removed the net5 build, I wasn't sure how you'd feel about that. I've also not changed the build that runs on main as I thought I'd get your feedback.

This now runs the legacy unit tests as part of the PR onto develop.