### PR TITLE
Upgrade Cocoon to use YARP version 1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Once running the following endpoints will now be available:
 * http://localhost:5003 - MVC
 * http://localhost:5005 - BlazorServer
 
-## Running tests with playwrite
+## Running tests with PlayWright
 
 Install the CLI tooling.
 ```

--- a/main/src/ReCode.Cocoon.Proxy/Proxy/CocoonProxyServicesExtensions.cs
+++ b/main/src/ReCode.Cocoon.Proxy/Proxy/CocoonProxyServicesExtensions.cs
@@ -1,7 +1,7 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using ReCode.Cocoon.Proxy.Proxy;
-using Yarp.ReverseProxy.Service.Proxy;
+using Yarp.ReverseProxy.Forwarder;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
@@ -18,7 +18,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton<CocoonProxy>(provider => new CocoonProxy(
                 configuration, 
                 provider.GetService<ILogger<CocoonProxy>>(), 
-                provider.GetService<IHttpProxy>(), cocoonProxyOptions));
+                provider.GetService<IHttpForwarder>(), cocoonProxyOptions));
 
             return ReverseProxyBuilder(services, configuration);
         }

--- a/main/src/ReCode.Cocoon.Proxy/Proxy/RedirectTransformer.cs
+++ b/main/src/ReCode.Cocoon.Proxy/Proxy/RedirectTransformer.cs
@@ -2,7 +2,7 @@
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Yarp.ReverseProxy.Service.Proxy;
+using Yarp.ReverseProxy.Forwarder;
 
 namespace ReCode.Cocoon.Proxy.Proxy
 {
@@ -15,7 +15,7 @@ namespace ReCode.Cocoon.Proxy.Proxy
             _destinationPrefix = destinationPrefix;
         }
 
-        public override async Task TransformResponseAsync(HttpContext context, HttpResponseMessage response)
+        public override ValueTask TransformResponseTrailersAsync(HttpContext context, HttpResponseMessage response)
         {
             var location = response.Headers.Location;
             
@@ -24,7 +24,7 @@ namespace ReCode.Cocoon.Proxy.Proxy
                 var relative = location.PathAndQuery;
                 response.Headers.Location = new Uri(relative, UriKind.Relative);
             }
-            await base.TransformResponseAsync(context, response);
+            return base.TransformResponseTrailersAsync(context, response);
         }
     }
 }

--- a/main/src/ReCode.Cocoon.Proxy/ReCode.Cocoon.Proxy.csproj
+++ b/main/src/ReCode.Cocoon.Proxy/ReCode.Cocoon.Proxy.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="MessagePack" Version="2.2.85" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.1" />
-    <PackageReference Include="Yarp.ReverseProxy" Version="1.0.0-preview.10.21168.2" />
+    <PackageReference Include="Yarp.ReverseProxy" Version="1.0.0" />
   </ItemGroup>
 
 </Project>

--- a/main/src/ReCode.Cocoon.Proxy/ReCode.Cocoon.Proxy.csproj
+++ b/main/src/ReCode.Cocoon.Proxy/ReCode.Cocoon.Proxy.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="MessagePack" Version="2.2.85" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.1" />
-    <PackageReference Include="Yarp.ReverseProxy" Version="1.0.0" />
+    <PackageReference Include="Yarp.ReverseProxy" Version="1.0.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Upgraded Cocoon to use version 1.0.0 of the `Yarp.ReverseProxy` package.